### PR TITLE
Facebook auth secure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,5 @@ MASTER_KEY=masterKey
 JWT_SECRET=jwtSecret
 FLICKR_KEY=flickrKey
 WATSON_KEY=watsonKey
+FB_APP_SECRET=fbAppSecret
+FB_APP_SECRET_DEV=fbAppSecretDev

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,4 @@ env:
   - JWT_SECRET=jwtSecret
   - FLICKR_KEY=flickrKey
   - WATSON_KEY=watsonKey
+  - FB_APP_SECRET_DEV=fbAppSecretDev

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ addons:
     - g++-4.8
 script:
   - npm test -- -i --coverage
+after_success:
+  - bash <(curl -s https://codecov.io/bash)
 env:
   global:
   - CXX=g++-4.8
@@ -18,4 +20,5 @@ env:
   - JWT_SECRET=jwtSecret
   - FLICKR_KEY=flickrKey
   - WATSON_KEY=watsonKey
+  - FB_APP_SECRET=fbAppSecret
   - FB_APP_SECRET_DEV=fbAppSecretDev

--- a/src/config.js
+++ b/src/config.js
@@ -40,6 +40,7 @@ const config = {
     }
   },
   test: {
+    fbAppSecret: requireProcessEnv('FB_APP_SECRET_DEV'),
     mongo: {
       uri: 'mongodb://localhost/trama-test',
       options: {
@@ -48,6 +49,7 @@ const config = {
     }
   },
   development: {
+    fbAppSecret: requireProcessEnv('FB_APP_SECRET_DEV'),
     mongo: {
       uri: 'mongodb://localhost/trama-dev',
       options: {
@@ -58,6 +60,7 @@ const config = {
   production: {
     ip: process.env.IP || undefined,
     port: process.env.PORT || 8080,
+    fbAppSecret: requireProcessEnv('FB_APP_SECRET'),
     mongo: {
       uri: process.env.MONGODB_URI || 'mongodb://localhost/trama'
     }

--- a/src/config.js
+++ b/src/config.js
@@ -31,6 +31,7 @@ const config = {
     jwtSecret: requireProcessEnv('JWT_SECRET'),
     flickrKey: requireProcessEnv('FLICKR_KEY'),
     watsonKey: requireProcessEnv('WATSON_KEY'),
+    fbAppSecret: requireProcessEnv('FB_APP_SECRET'),
     mongo: {
       options: {
         db: {
@@ -40,7 +41,6 @@ const config = {
     }
   },
   test: {
-    fbAppSecret: requireProcessEnv('FB_APP_SECRET_DEV'),
     mongo: {
       uri: 'mongodb://localhost/trama-test',
       options: {
@@ -60,7 +60,6 @@ const config = {
   production: {
     ip: process.env.IP || undefined,
     port: process.env.PORT || 8080,
-    fbAppSecret: requireProcessEnv('FB_APP_SECRET'),
     mongo: {
       uri: process.env.MONGODB_URI || 'mongodb://localhost/trama'
     }

--- a/src/services/facebook/index.js
+++ b/src/services/facebook/index.js
@@ -1,4 +1,9 @@
+import crypto from 'crypto'
 import request from 'request-promise'
+import { fbAppSecret } from '../../config'
+
+const getAppSecretProof = (accessToken) =>
+  crypto.createHmac('sha256', fbAppSecret).update(accessToken).digest('hex')
 
 export const getUser = (accessToken) =>
   request({
@@ -6,6 +11,7 @@ export const getUser = (accessToken) =>
     json: true,
     qs: {
       access_token: accessToken,
+      appsecret_proof: getAppSecretProof(accessToken),
       fields: 'id, name, email'
     }
   }).then(({ id, name, email }) => ({


### PR DESCRIPTION
Currently, we are accepting any Facebook access_token to authenticate the user, even if the access_token wasn't originated by our Facebook App.

This PR adds one more layer of security while authenticating through Facebook by sending a `appsecret_proof` to the Facebook Graph API.

The downside is we need to add two more environment variable: `FB_APP_SECRET` and `FB_APP_SECRET_DEV` (the last one comes from the fb test app).